### PR TITLE
Update BMF Data Convert Backend Python docs

### DIFF
--- a/content/en/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/en/docs/bmf/getting_started_yourself/install/_index.md
@@ -406,6 +406,7 @@ After completing preparatory works above, you can compile BMF under Mac OS and u
 ```
 git submodule update --init --recursive
 sed -i '' '/sigma_gn /s/^/\/\//g' bmf/hml/third_party/benchmark/src/complexity.cc
+export BMF_PYTHON_VERSION="3.9"
 ./build_osx.sh
 ```
 

--- a/content/en/docs/bmf/multiple_features/data_backend/_index.md
+++ b/content/en/docs/bmf/multiple_features/data_backend/_index.md
@@ -8,7 +8,7 @@ weight: 3
 
 ### Background
 An all-in-one solution is needed when multiple dimension factors are involved in video process pipeline such as CPU/GPU devices, YUV420/NV12 or RGB24/RGB48, and AVFrame or Torch structure.
-As a framework, each module just focuses on its own target and data requirement, but it becomes complex when multiple modules work together as below supper resolution pipeline:
+As a framework, each module just focuses on its own target and data requirement, but it becomes complex when multiple modules work together as seen below in the super resolution pipeline:
 <img src="/img/docs/backend.png" style="zoom:50%;" />
 
 We can see that different modules have their own data requirements. The decode module outputs FFmpeg AVFrame in YUV420 pixel format, which is located on the CPU memory. The Trt SR module requires that the input data is an RGB24 torch after hardware acceleration and is located on the GPU memory. For SR through the Trt module, the output data needs to be encoded by the GPU, so the HW encode module can get AVFrame with NV12 pixel format located on the GPU memory and encode it by the GPU.
@@ -17,8 +17,6 @@ It tends to include the capabilities of video data conversion below:
 - pixel format and color space
 - devices between CPU and GPU
 - different media types such as avframe, cvmat and torch
-
-Currently, the backend interface is under testing and demo integration. The fully unified and easy to use interface and examples for both C++ and Python will be released soon.
 
 ### C++ Interface
 
@@ -32,11 +30,10 @@ Currently, the backend interface is under testing and demo integration. The full
 BMF_API VideoFrame bmf_convert(VideoFrame& src_vf, const MediaDesc &src_dp, const MediaDesc &dst_dp);
 ```
 
-This interface allows the conversion of a source VideoFrame to a destination VideoFrame. If the media_type in the source MediaDesc is different from the media_type in the destination MediaDesc, it indicates that the conversion will involve the transformation between VideoFrame and a third-party data structure. Accessing the third-party data structure requires the use of the private_attach and private_get methods of the VideoFrame. 
+This interface allows the conversion of a source VideoFrame to a destination VideoFrame. If the media_type in the source MediaDesc is different from the media_type in the destination MediaDesc, it indicates that the conversion will involve the transformation between VideoFrame and a third-party data structure. Accessing a third-party data structure requires the use of the private_attach and private_get methods of the VideoFrame. 
 
 #### VideoFrame scale and colorspace conversion
-
-use `bmf_convert` do scale and csc
+Using `bmf_convert` for scale and csc:
 
 ```c++
     MediaDesc dp;
@@ -47,11 +44,11 @@ use `bmf_convert` do scale and csc
     EXPECT_EQ(dst_vf.width(), 1920);
     EXPECT_EQ(dst_vf.height(), 960);
     EXPECT_EQ(dst_vf.frame().format(), hmp::PF_YUV420P);
-
 ```
 
 #### Device memory transfer
-Samples show how to transfer the input video frame memory on GPU memory.
+The following code sample shows how to transfer the input video frame memory to GPU memory: 
+
 ```c++
     MediaDesc dp;
     dp.device(hmp::Device("gpu")); // or hmp::Device("cpu")
@@ -59,8 +56,7 @@ Samples show how to transfer the input video frame memory on GPU memory.
 ```
 
 #### Conversion between VideoFrame and third-party data structure
-
-BMF support the following types of third-party structure conversion with VideoFrame
+BMF supports the following types of third-party structure conversion with VideoFrame
 
 1. FFmpeg AVFrame
 2. Opencv cv::Mat
@@ -77,7 +73,7 @@ Here, FFmpeg AVFrame is used as an example to illustrate the conversion. Other t
 
 It is important to note that the lifecycle of the structure pointed to by the pointer obtained from private_get is managed by the VideoFrame to which it belongs.
 
-some example code snippet：
+See example code snippet：
 
 ```c++
     #include <bmf/sdk/av_convertor.h>
@@ -94,7 +90,6 @@ some example code snippet：
     EXPECT_EQ(frame->width, 1920);
     EXPECT_EQ(frame->height, 1080);
     EXPECT_EQ(frame->format, AV_PIX_FMT_RGB24);
-
 ```
 
 ##### AVFrame to VideoFrame
@@ -104,7 +99,7 @@ some example code snippet：
 3. use `bmf_convert` to convert
 4. get the return VideoFrame
 
-some example code snippet：
+See example code snippet：
 
 ```c++
     VideoFrame src_with_avf;
@@ -112,14 +107,36 @@ some example code snippet：
     MediaDesc src_dp;
     src_dp.pixel_format(hmp::PF_RGB24).media_type(MediaType::kAVFrame);
     VideoFrame vf = bmf_convert(src_with_avf, src_dp, MediaDesc{});
-
 ```
 
-
 ### Python Interface
-The unified `bmf_convert` as C++ will be designed and implemented later.
+The `bmf_convert` functionality is provided in Python via pybind11 bindings to the C++ implementation. Usage is much the same as the C++ snippets above. Some legacy data conversion examples are included below where the conversion is not currently supported by `bmf_convert`. 
 
 #### Scale and colorspace conversion
+See the following example of using `bmf_convert` to convert a video frame from RGB to NV12 and scale the image to half-width and half-height: 
+
+```python
+    from bmf import *
+    import bmf.hml.hmp as mp
+    from bmf.lib._bmf.sdk import MediaDesc, bmf_convert
+
+    # construct a video frame
+    width = 640
+    height = 360
+    RGB = mp.PixelInfo(mp.PixelFormat.kPF_RGB24, mp.ColorSpace.kCS_BT709)
+    vf = VideoFrame(width, height, pix_info=RGB)
+
+    # generate a media description of the converted media
+    # ... half-width, half-height
+    # ... NV12 pixel format and BT470BG color space
+    dst_md = MediaDesc().width(width//2).height(height//2)
+    dst_md.pixel_format(mp.PixelFormat.kPF_NV12).color_space(mp.ColorSpace.kCS_BT470BG)
+
+    # do the conversion with `bmf_convert(...)`
+    out_vf = bmf_convert(src_vf, MediaDesc(), dst_md)
+```
+
+Currently `bmf_convert` does not support rotate, or color depth conversions. However, this functionality can be achieved using the following legacy functions: 
 
 `bmf.hml.hmp.img.rgb_to_yuv`
 
@@ -131,8 +148,7 @@ The unified `bmf_convert` as C++ will be designed and implemented later.
 
 `bmf.hml.hmp.img.rotate`
 
-Sample code:
-
+The following legacy snippet does a color space conversion from RGB to NV12, and allows for specifying the color range:
 
 ```python
     from bmf import *
@@ -146,7 +162,14 @@ Sample code:
 ```
 
 #### Device memory transfer
-Interface used:
+Using `bmf_convert`: 
+```python
+    cpu_vf = pk.get(VideoFrame)
+    dst_md = MediaDesc().device(mp.kCUDA)
+    gpu_vf = bmf_convert(cpu_vf, MediaDesc(), dst_md)
+```
+
+Or using the legacy approach:
 
 `VideoFrame.frame().device()` gets the Device property
 
@@ -163,17 +186,43 @@ Sample code:
         vf = vf.cuda()
     #...
 ```
+
 #### Conversion between VideoFrame and third-party data structure
 In python API, those types of third-party data type are supported:
 - VideoFrame, which is the general class of video frame in BMF. And `VideoFrame` includes `Frame` as member
 - numpy
 - torch
 
+The media_type property on the MediaDesc instance is used to identify the data type when doing conversions with `bmf_convert`. The following options are available: 
+
+`bmf.lib._bmf.sdk.kBMFVideoFrame` - BMF video frame
+
+`bmf.lib._bmf.sdk.kAVFrame` - ffmpeg frame
+
+`bmf.lib._bmf.sdk.kATTensor` - torch
+
+`bmf.lib._bmf.sdk.kTensor`
+
+`bmf.lib._bmf.sdk.kCVMat` - opencv mat
+
+**NOTE**: conversions must be to-or-from a BMF video frame or a runtime error will be raised. 
+
+Convert ffmpeg AVFrame to BMF Video Frame: 
+```python
+    from bmf import *
+    import bmf.hml.hmp as mp
+    from bmf.lib._bmf.sdk import MediaDesc, bmf_convert, kAVFrame
+
+    vf = pkt.get(VideoFrame) # grab input AVFrame
+    src_md = MediaDesc().media_type(kAVFrame)
+    out_vf = bmf_convert(vf, src_md, MediaDesc())
+```
+
 `bmf.hml.hmp.Frame.numpy` converts a BMF Frame to numpy, and Frame can be included in VideoFrame
 
 `bmf.hml.hmp.Frame.from_numpy`
 
-Sample code
+Sample code:
 ```python
     from bmf import *
     import numpy as np

--- a/content/zh/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/install/_index.md
@@ -399,6 +399,7 @@ Mac OS 端编译时需要注意以下几点：
 ```
 brew unlink ffmpeg
 brew link ffmpeg@4
+export BMF_PYTHON_VERSION="3.9"
 brew link --force python@3.9 
 ```     
 


### PR DESCRIPTION
Updated the Python docs to reflect the `bmf_convert` functionality and promote adoption. Also fixed some typos. 

Remaining tasks:
* Chinese version still needs to be updated.