### PR TITLE
Update macOS name to the modern one

### DIFF
--- a/content/en/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/en/docs/bmf/getting_started_yourself/install/_index.md
@@ -366,9 +366,9 @@ Assuming that your local environment is a 64-bit Release version, the VS version
 After execution, the build_win_lite folder will generate the BMF.sln project file, which can be built by opening it through Visual Studio.
 
 
-### Mac OS
+### macOS
 
-When compiling on the Mac OS side, you need to pay attention to the following points:
+When compiling on the macOS side, you need to pay attention to the following points:
 1. Install FFmpeg and configure environment variables
 2. If the CPU chip of your Mac computer is an ARM architecture such as M1 or M2, the compatible version of Python is (3.9 - 3.10). The reason is that the Python arm version below 3.8 on the Mac is an experimental function and does not have much dependency support.
 3. Two pre-dependencies need to be installed: binutils and libncurses. Under ARM architecture, the former can be installed directly through brew install binutils, while the latter may require you to compile libncursew.
@@ -402,7 +402,7 @@ brew link --force python@3.9
 ```
 The above command will configure the installation path to ```/usr/local/opt/ncurses```. You can also change the path as needed. After compilation and installation are complete, you should be able to find the libncurses library file in the specified installation path. With the above steps, you can successfully compile and install libncurses on macOS. Please note that the process may change due to version updates.
 
-After completing preparatory works above, you can compile BMF under Mac OS and use the command, in some higher version compilers, you may encounter compilation errors of the benchmark library, and we have also dealt with them. You could make the compilation by using commands followed:
+After completing preparatory works above, you can compile BMF under macOS and use the command, in some higher version compilers, you may encounter compilation errors of the benchmark library, and we have also dealt with them. You could make the compilation by using commands followed:
 ```
 git submodule update --init --recursive
 sed -i '' '/sigma_gn /s/^/\/\//g' bmf/hml/third_party/benchmark/src/complexity.cc

--- a/content/zh/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/install/_index.md
@@ -366,9 +366,9 @@ bmf_ffmpeg integrates FFmpeg during compilation and compiles built-in Modules
 执行后，build_win_lite 文件夹会生成 BMF.sln 项目文件，通过 Visual Studio 打开即可构建。
 
 
-### Mac OS
+### macOS
 
-Mac OS 端编译时需要注意以下几点：
+macOS 端编译时需要注意以下几点：
 1. 安装 FFmpeg 并配置环境变量
 2. 如果您的 Mac 电脑的 CPU 芯片是 M1 或 M2 等 ARM 架构，则兼容的 Python 版本为（3.9 - 3.10）。因为 Mac 上 3.8 以下的 Python 版本是实验性功能，没有太多依赖支持。
 3. 需要安装两个预依赖项：binutils 和 libncurses。在 ARM 架构下，前者可以直接通过 brew install binutils 安装，而后者可能需要您编译 libncursew。
@@ -403,10 +403,10 @@ export BMF_PYTHON_VERSION="3.9"
 brew link --force python@3.9 
 ```     
 
-上面的命令将把安装路径配置为 ```/usr/local/opt/ncurses```。您也可以根据需要更改路径。编译安装完成后，可以在指定的安装路径中找到 libncurses 库文件。通过以上步骤，就可以在 mac OS 上成功编译并安装 libncurses。请注意，该流程可能会因版本更新而发生变化。
+上面的命令将把安装路径配置为 ```/usr/local/opt/ncurses```。您也可以根据需要更改路径。编译安装完成后，可以在指定的安装路径中找到 libncurses 库文件。通过以上步骤，就可以在 macOS 上成功编译并安装 libncurses。请注意，该流程可能会因版本更新而发生变化。
 
 
-完成以上准备工作后，您可以在 Mac OS 下编译 BMF，在一些高版本的编译器中，您可能会遇到 benchmark 库的编译错误，我们对此也进行了处理，您可以使用以下命令完成编译:
+完成以上准备工作后，您可以在 macOS 下编译 BMF，在一些高版本的编译器中，您可能会遇到 benchmark 库的编译错误，我们对此也进行了处理，您可以使用以下命令完成编译:
 ```
 git submodule update --init --recursive
 sed -i '' '/sigma_gn /s/^/\/\//g' bmf/hml/third_party/benchmark/src/complexity.cc


### PR DESCRIPTION
## Key Changes

- Modify Mac OS to macOS

> macOS hasn't been called "Mac OS" for a while
> 
> macOS is a more modern name, mac OS usually refers to Classic Mac OS which is the series of [operating systems](https://en.wikipedia.org/wiki/Operating_system) developed for the [Macintosh](https://en.wikipedia.org/wiki/Mac_(computer)) family of [personal computers](https://en.wikipedia.org/wiki/Personal_computer) by [Apple Computer, Inc.](https://en.wikipedia.org/wiki/Apple_Computer,_Inc.) from 1984 to 2001, starting with [System 1](https://en.wikipedia.org/wiki/System_1) and ending with [Mac OS 9](https://en.wikipedia.org/wiki/Mac_OS_9). you can find more details at this [link](https://en.wikipedia.org/wiki/Classic_Mac_OS)