### PR TITLE
Fix typos in cpp api doc (jsonparam, module)

### DIFF
--- a/content/en/docs/bmf/api/api_in_cpp/jsonparam/_index.md
+++ b/content/en/docs/bmf/api/api_in_cpp/jsonparam/_index.md
@@ -7,9 +7,13 @@ weight: 4
 [//]: <> (REF_MD: classJsonParam.html)
 
 
-  [Public Member Functions](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-member-functions)  |  [Public Attributes](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-attributes)  |  [List of all members](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/)  # JsonParam Class Reference
+  [Public Member Functions](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-member-functions)  |  [Public Attributes](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-attributes)  |  [List of all members](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/) 
 
-json_param.h ## Public Member Functions
+  # JsonParam Class Reference
+
+json_param.h 
+
+## Public Member Functions
 
 
    [JsonParam](#jsonparam-14) ()=default
@@ -105,7 +109,7 @@ void   [merge_patch](#merge_patch) (const [JsonParam](https://babitmf.github.io/
  ```
 JsonParam::JsonParam (  )  
 ```
- defaultdefault
+ default
 
 
 
@@ -141,7 +145,7 @@ JsonParam::JsonParam ( std::string opt_str )
  ```
 JsonParam::JsonParam (  bmf_nlohmann::json json_value )  
 ```
- explicitexplicit
+ explicit
 
 
 
@@ -187,7 +191,7 @@ erase the key content from json param
  ```
 T JsonParam::get ( U name ) const 
 ```
- inlineinline
+ inline
 
 
 
@@ -195,10 +199,9 @@ T JsonParam::get ( U name ) const
 
 
 ```
-                             {
-             return json_value_[name].template get<T>();
-         }
-
+  {
+    return json_value_[name].template get<T>();
+  }
 ```
 
 ###  get_double()
@@ -231,7 +234,7 @@ get double value list according to the key name
 
 **Parameters**
  - **name** name of key 
- - **result** result of doule list 
+ - **result** result of double list 
 
 
 
@@ -476,7 +479,7 @@ merge json patch to current target
  ```
  JsonParam JsonParam::operator[]( T name )  
 ```
- inlineinline
+ inline
 
 
 
@@ -484,10 +487,9 @@ merge json patch to current target
 
 
 ```
-                                      {
-             return JsonParam(json_value_[name]);
-         }
-
+  {
+    return JsonParam(json_value_[name]);
+  }
 ```
 
 ###  parse()
@@ -540,7 +542,7 @@ store json content to file
  ```
 T JsonParam::to (  ) const 
 ```
- inlineinline
+ inline
 
 
 
@@ -548,10 +550,9 @@ T JsonParam::to (  ) const
 
 
 ```
-                      {
-             return json_value_.get<T>();
-         }
-
+  {
+    return json_value_.get<T>();
+  }
 ```
 ## Member Data Documentation
 

--- a/content/en/docs/bmf/api/api_in_cpp/module/_index.md
+++ b/content/en/docs/bmf/api/api_in_cpp/module/_index.md
@@ -7,9 +7,13 @@ weight: 5
 [//]: <> (REF_MD: classbmf__sdk_1_1Module.html)
 
 
-  [Public Member Functions](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-member-functions)  |  [Public Attributes](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-attributes)  |  List of all members  # bmf_sdk::Module Class Referenceabstract
+  [Public Member Functions](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-member-functions)  |  [Public Attributes](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-attributes)  |  List of all members  
+  
+  # bmf_sdk::Module Class Reference abstract
 
-module.h ## Public Member Functions
+module.h 
+
+## Public Member Functions
 
 
    [Module](#module) (int32_t node_id=-1, [JsonParam](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/) json_param= [JsonParam](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/) ())
@@ -87,7 +91,7 @@ bmf_sdk::Module::Module ( int32_t node_id = -1,
    JsonParam json_param = JsonParam() 
  )   
 ```
- inlineinline
+ inline virtual
 
 
 
@@ -101,11 +105,10 @@ bmf_sdk::Module::Module ( int32_t node_id = -1,
 
 
 ```
-                                                                      { 
-         configure_bmf_log();
-         node_id_ = node_id;
-     };
-
+ { 
+    configure_bmf_log();
+    node_id_ = node_id;
+ };
 ```
 
 ###  ~Module()
@@ -113,9 +116,7 @@ bmf_sdk::Module::Module ( int32_t node_id = -1,
  ```
 virtual bmf_sdk::Module::~Module (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -134,9 +135,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::close (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -158,9 +157,7 @@ close module and release resources
  ```
 virtual int32_t bmf_sdk::Module::dynamic_reset (  JsonParam opt_reset )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -187,9 +184,7 @@ dynamic reset module according to the jsonParam
  ```
 virtual int32_t bmf_sdk::Module::flush (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -211,9 +206,7 @@ set module mode to flush data
  ```
 virtual bool bmf_sdk::Module::get_graph_config (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -240,9 +233,7 @@ if the module is subgraph get the graph config
  ```
 virtual int32_t bmf_sdk::Module::get_input_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -269,9 +260,7 @@ get input stream info of module
  ```
 virtual int32_t bmf_sdk::Module::get_module_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -298,9 +287,7 @@ get info of module
  ```
 virtual int32_t bmf_sdk::Module::get_output_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -327,9 +314,7 @@ get output stream info of module
  ```
 virtual int32_t bmf_sdk::Module::init (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -351,9 +336,7 @@ init module
  ```
 virtual bool bmf_sdk::Module::is_hungry ( int input_stream_id )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -380,9 +363,7 @@ check the input stream if need data
  ```
 virtual bool bmf_sdk::Module::is_infinity (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -404,9 +385,7 @@ check the module type
  ```
 virtual bool bmf_sdk::Module::is_subgraph (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -428,9 +407,7 @@ check the module is subgraph
  ```
 virtual bool bmf_sdk::Module::need_hungry_check ( int input_stream_id )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -457,7 +434,7 @@ check the input stream if need hungry check
  ```
 virtual int32_t bmf_sdk::Module::process (  Task &task )  
 ```
- pure virtualpure virtual
+ pure virtual
 
 
 
@@ -481,9 +458,7 @@ virtual int32_t bmf_sdk::Module::report (  JsonParam &json_param,
   int hints = 0 
  )   
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -511,9 +486,7 @@ report module stats
  ```
 virtual int32_t bmf_sdk::Module::reset (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -535,9 +508,7 @@ reset module
  ```
 virtual void bmf_sdk::Module::set_callback ( std::function< CBytes(int64_t, CBytes)> callback_endpoint )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -561,9 +532,7 @@ set the graph callback of module
  ```
 virtual int32_t bmf_sdk::Module::set_input_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -590,9 +559,7 @@ set input stream info of module
  ```
 virtual int32_t bmf_sdk::Module::set_output_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 

--- a/content/zh/docs/bmf/api/api_in_cpp/jsonparam/_index.md
+++ b/content/zh/docs/bmf/api/api_in_cpp/jsonparam/_index.md
@@ -7,9 +7,13 @@ weight: 4
 [//]: <> (REF_MD: classJsonParam.html)
 
 
-  [公有成员函数](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-member-functions)  |  [公共属性](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-attributes)  |  [成员清单](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/)  # JsonParam Class Reference
+  [公有成员函数](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-member-functions)  |  [公共属性](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/#public-attributes)  |  [成员清单](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/)  
+  
+  # JsonParam Class Reference
 
-json_param.h ## Public Member Functions
+json_param.h 
+
+## Public Member Functions
 
 
    [JsonParam](#jsonparam-14) ()=default
@@ -105,7 +109,7 @@ void   [merge_patch](#merge_patch) (const [JsonParam](https://babitmf.github.io/
  ```
 JsonParam::JsonParam (  )  
 ```
- defaultdefault
+ default
 
 
 
@@ -141,7 +145,7 @@ JsonParam::JsonParam ( std::string opt_str )
  ```
 JsonParam::JsonParam (  bmf_nlohmann::json json_value )  
 ```
- explicitexplicit
+ explicit
 
 
 
@@ -187,7 +191,7 @@ int JsonParam::erase ( std::string name )
  ```
 T JsonParam::get ( U name ) const 
 ```
- inlineinline
+ inline
 
 
 
@@ -195,10 +199,9 @@ T JsonParam::get ( U name ) const
 
 
 ```
-                             {
-             return json_value_[name].template get<T>();
-         }
-
+  {
+    return json_value_[name].template get<T>();
+  }
 ```
 
 ###  get_double()
@@ -231,7 +234,7 @@ int JsonParam::get_double_list ( std::string name,
 
 **Parameters**
  - **name**：key 的名称
- - **result** doule list 的结果 
+ - **result** double list 的结果 
 
 
 
@@ -476,7 +479,7 @@ void JsonParam::merge_patch ( const JsonParam &json_patch )
  ```
  JsonParam JsonParam::operator[]( T name )  
 ```
- inlineinline
+ inline
 
 
 
@@ -484,10 +487,9 @@ void JsonParam::merge_patch ( const JsonParam &json_patch )
 
 
 ```
-                                      {
-             return JsonParam(json_value_[name]);
-         }
-
+  {
+    return JsonParam(json_value_[name]);
+  }
 ```
 
 ###  parse()
@@ -540,7 +542,7 @@ int JsonParam::store ( std::string file_name )
  ```
 T JsonParam::to (  ) const 
 ```
- inlineinline
+ inline
 
 
 
@@ -548,10 +550,9 @@ T JsonParam::to (  ) const
 
 
 ```
-                      {
-             return json_value_.get<T>();
-         }
-
+  {
+     return json_value_.get<T>();
+  }
 ```
 ## 成员数据文档
 

--- a/content/zh/docs/bmf/api/api_in_cpp/module/_index.md
+++ b/content/zh/docs/bmf/api/api_in_cpp/module/_index.md
@@ -7,9 +7,13 @@ weight: 5
 [//]: <> (REF_MD: classbmf__sdk_1_1Module.html)
 
 
-  [公有成员函数](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-member-functions)  |  [公共属性](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-attributes)  |  List of all members  # bmf_sdk::Module Class Referenceabstract
+  [公有成员函数](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-member-functions)  |  [公共属性](https://babitmf.github.io/docs/bmf/api/api_in_cpp/module/#public-attributes)  |  List of all members  
+  
+  # bmf_sdk::Module Class Referenceabstract
 
-module.h ## Public Member Functions
+module.h 
+
+## Public Member Functions
 
 
    [Module](#module) (int32_t node_id=-1, [JsonParam](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/) json_param= [JsonParam](https://babitmf.github.io/docs/bmf/api/api_in_cpp/jsonparam/) ())
@@ -87,7 +91,7 @@ bmf_sdk::Module::Module ( int32_t node_id = -1,
    JsonParam json_param = JsonParam() 
  )   
 ```
- inlineinline
+ inline virtual
 
 
 
@@ -101,11 +105,10 @@ bmf_sdk::Module::Module ( int32_t node_id = -1,
 
 
 ```
-                                                                      { 
-         configure_bmf_log();
-         node_id_ = node_id;
-     };
-
+ { 
+    configure_bmf_log();
+    node_id_ = node_id;
+ };
 ```
 
 ###  ~Module()
@@ -113,9 +116,7 @@ bmf_sdk::Module::Module ( int32_t node_id = -1,
  ```
 virtual bmf_sdk::Module::~Module (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -134,9 +135,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::close (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -158,9 +157,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::dynamic_reset (  JsonParam opt_reset )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -187,9 +184,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::flush (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -211,9 +206,7 @@ virtual
  ```
 virtual bool bmf_sdk::Module::get_graph_config (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -240,9 +233,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::get_input_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -269,10 +260,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::get_module_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
-
+ inline virtual
 
 
 
@@ -297,9 +285,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::get_output_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -325,9 +311,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::init (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -349,9 +333,7 @@ virtual
  ```
 virtual bool bmf_sdk::Module::is_hungry ( int input_stream_id )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -378,9 +360,7 @@ virtual
  ```
 virtual bool bmf_sdk::Module::is_infinity (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -402,9 +382,7 @@ virtual
  ```
 virtual bool bmf_sdk::Module::is_subgraph (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -426,9 +404,7 @@ virtual
  ```
 virtual bool bmf_sdk::Module::need_hungry_check ( int input_stream_id )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -455,7 +431,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::process (  Task &task )  
 ```
- pure virtualpure virtual
+ pure virtual
 
 
 
@@ -479,9 +455,7 @@ virtual int32_t bmf_sdk::Module::report (  JsonParam &json_param,
   int hints = 0 
  )   
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -509,9 +483,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::reset (  )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -533,9 +505,7 @@ virtual
  ```
 virtual void bmf_sdk::Module::set_callback ( std::function< CBytes(int64_t, CBytes)> callback_endpoint )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -559,9 +529,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::set_input_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 
@@ -588,9 +556,7 @@ virtual
  ```
 virtual int32_t bmf_sdk::Module::set_output_stream_info (  JsonParam &json_param )  
 ```
- inlinevirtualinline
-
-virtual
+ inline virtual
 
 
 


### PR DESCRIPTION
This mistake still can be found in other cpp api doc, this light PR just test the fix if is correct, then we'll fix other doc.