### PR TITLE
explicitly add download resources link in 'Getting Started' section

### DIFF
--- a/content/en/docs/bmf/getting_started_yourself/_index.md
+++ b/content/en/docs/bmf/getting_started_yourself/_index.md
@@ -5,6 +5,7 @@ weight: 3
 ---
 
 
+If you need example files, you can find them in <https://github.com/BabitMF/bmf/releases/download/files/files.tar.gz>
 
 ## Brief Introduction
 

--- a/content/zh/docs/bmf/getting_started_yourself/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/_index.md
@@ -5,6 +5,7 @@ weight: 3
 ---
 
 
+如果您需要示例文件，可以从这里下载：<https://github.com/BabitMF/bmf/releases/download/files/files.tar.gz>
 
 ## 简介
 


### PR DESCRIPTION
To address the issue of unclear guidance on resource files mentioned in Issues https://github.com/BabitMF/bmf/issues/66 .