### PR TITLE
docs: Add CMake version requirement for Linux source builds

### DIFF
--- a/content/en/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/en/docs/bmf/getting_started_yourself/install/_index.md
@@ -312,6 +312,14 @@ export PYTHONPATH=$(pwd)/output/bmf/lib:$(pwd)/output
 
 BMF supports compilation and builds on three platforms: Linux, Windows, and Mac. You can choose the method you want to use according to your needs.
 
+**Important Note: CMake Version Requirements**
+When building BMF from source:
+- Base requirement: CMake 3.5 or higher
+- If CUDA support is needed (enabled by default), CMake 3.17 or higher is required
+  
+You can check your current CMake version by running `cmake --version`. If the version does not meet the requirements, please upgrade CMake.
+
+
 ### Linux
 
 ```Shell

--- a/content/en/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/en/docs/bmf/getting_started_yourself/install/_index.md
@@ -319,7 +319,6 @@ When building BMF from source:
   
 You can check your current CMake version by running `cmake --version`. If the version does not meet the requirements, please upgrade CMake.
 
-
 ### Linux
 
 ```Shell

--- a/content/zh/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/install/_index.md
@@ -315,10 +315,11 @@ BMF 支持在以下三个平台编译和构建：Linux、Windows 和 Mac。您�
 ### Linux
 
 **重要提示：CMake 版本要求**
-在 Linux 环境下从源代码构建 BMF 时：
+从源代码构建 BMF 时：
 - 基础版本要求：CMake 3.5 或更高版本
-- 如果需要 CUDA 支持，则要求 CMake 3.17 或更高版本
-- 您可以通过运行 `cmake --version` 来检查当前的 CMake 版本。如果版本不满足要求，请先升级 CMake。
+- 如果需要 CUDA 支持（默认开启），则要求 CMake 3.17 或更高版本
+
+您可以通过运行 `cmake --version` 来检查当前的 CMake 版本。如果版本不满足要求，请先升级 CMake。
 
 ```Shell
 git clone https://github.com/BabitMF/bmf bmf

--- a/content/zh/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/install/_index.md
@@ -315,7 +315,10 @@ BMF 支持在以下三个平台编译和构建：Linux、Windows 和 Mac。您�
 ### Linux
 
 **重要提示：CMake 版本要求**
-在 Linux 环境下从源代码构建 BMF 时，请确保您的系统中安装的 CMake 版本 **不低于 3.17**。较低版本的 CMake 可能会导致构建失败或出现不可预知的错误。您可以通过运行 `cmake --version` 来检查当前的 CMake 版本。如果版本过低，请先升级 CMake。
+在 Linux 环境下从源代码构建 BMF 时：
+- 基础版本要求：CMake 3.5 或更高版本
+- 如果需要 CUDA 支持，则要求 CMake 3.17 或更高版本
+- 您可以通过运行 `cmake --version` 来检查当前的 CMake 版本。如果版本不满足要求，请先升级 CMake。
 
 ```Shell
 git clone https://github.com/BabitMF/bmf bmf

--- a/content/zh/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/install/_index.md
@@ -312,14 +312,14 @@ export PYTHONPATH=$(pwd)/output/bmf/lib:$(pwd)/output
 
 BMF 支持在以下三个平台编译和构建：Linux、Windows 和 Mac。您可以根据自己的需要选择您想要使用的方法。
 
-### Linux
-
 **重要提示：CMake 版本要求**
 从源代码构建 BMF 时：
 - 基础版本要求：CMake 3.5 或更高版本
 - 如果需要 CUDA 支持（默认开启），则要求 CMake 3.17 或更高版本
 
 您可以通过运行 `cmake --version` 来检查当前的 CMake 版本。如果版本不满足要求，请先升级 CMake。
+
+### Linux
 
 ```Shell
 git clone https://github.com/BabitMF/bmf bmf

--- a/content/zh/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/zh/docs/bmf/getting_started_yourself/install/_index.md
@@ -314,6 +314,9 @@ BMF 支持在以下三个平台编译和构建：Linux、Windows 和 Mac。您�
 
 ### Linux
 
+**重要提示：CMake 版本要求**
+在 Linux 环境下从源代码构建 BMF 时，请确保您的系统中安装的 CMake 版本 **不低于 3.17**。较低版本的 CMake 可能会导致构建失败或出现不可预知的错误。您可以通过运行 `cmake --version` 来检查当前的 CMake 版本。如果版本过低，请先升级 CMake。
+
 ```Shell
 git clone https://github.com/BabitMF/bmf bmf
 cd bmf


### PR DESCRIPTION
Specify that CMake version 3.17 or higher is required for building BMF from source on Linux to ensure successful compilation.