### PR TITLE
docs: update CMake version requirements in installation documentation

### DIFF
--- a/content/en/docs/bmf/getting_started_yourself/install/_index.md
+++ b/content/en/docs/bmf/getting_started_yourself/install/_index.md
@@ -312,6 +312,13 @@ export PYTHONPATH=$(pwd)/output/bmf/lib:$(pwd)/output
 
 BMF supports compilation and builds on three platforms: Linux, Windows, and Mac. You can choose the method you want to use according to your needs.
 
+**Important Note: CMake Version Requirements**
+When building BMF from source:
+- Base requirement: CMake 3.5 or higher
+- If CUDA support is needed (enabled by default), CMake 3.17 or higher is required
+
+You can check your current CMake version by running `cmake --version`. If the version does not meet the requirements, please upgrade CMake.
+
 ### Linux
 
 ```Shell


### PR DESCRIPTION
Enhance the installation documentation by adding CMake version requirements for building BMF from source:

- Introduced a clear note at the beginning of the "Building from Source" section
- Specified that the base requirement is CMake 3.5 or higher
- Clarified that CMake 3.17 or higher is required if CUDA support is enabled (default)
- Included instructions for checking the current CMake version and upgrading if necessary

This update ensures users are aware of the necessary CMake versions before attempting to build BMF, improving the overall user experience and reducing potential build issues.